### PR TITLE
Remove unused reference to non-existent FluentAssertions

### DIFF
--- a/src/DotnetIgnoreCliTool/DotnetIgnoreCliTool.csproj
+++ b/src/DotnetIgnoreCliTool/DotnetIgnoreCliTool.csproj
@@ -41,12 +41,4 @@
     <PackageReference Include="PowerArgs" Version="3.0.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="FluentAssertions">
-      <HintPath>..\..\..\..\Users\arasz\.nuget\packages\fluentassertions\5.3.2\lib\netstandard2.0\FluentAssertions.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
-
-
 </Project>


### PR DESCRIPTION
Before this PR, doing a `dotnet build` gives the warning:

    warning MSB3245: Could not resolve this reference. Could not locate the assembly "FluentAssertions"

The full build output is:

```
Microsoft (R) Build Engine version 15.8.169+g1ccb72aefa for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restoring packages for A:\dotnet-ignore\src\DotnetIgnoreCliTool\DotnetIgnoreCliTool.csproj...
  Restoring packages for A:\dotnet-ignore\test\DotnetIgnoreCliToolTests\DotnetIgnoreCliToolTests.csproj...
  Restore completed in 56.34 ms for A:\dotnet-ignore\test\DotnetIgnoreCliToolTests\DotnetIgnoreCliToolTests.csproj.
  Generating MSBuild file A:\dotnet-ignore\src\DotnetIgnoreCliTool\obj\DotnetIgnoreCliTool.csproj.nuget.g.props.
  Generating MSBuild file A:\dotnet-ignore\src\DotnetIgnoreCliTool\obj\DotnetIgnoreCliTool.csproj.nuget.g.targets.
  Restore completed in 278.4 ms for A:\dotnet-ignore\src\DotnetIgnoreCliTool\DotnetIgnoreCliTool.csproj.
  Generating MSBuild file A:\dotnet-ignore\test\DotnetIgnoreCliToolTests\obj\DotnetIgnoreCliToolTests.csproj.nuget.g.props.
  Generating MSBuild file A:\dotnet-ignore\test\DotnetIgnoreCliToolTests\obj\DotnetIgnoreCliToolTests.csproj.nuget.g.targets.
  Restore completed in 553.9 ms for A:\dotnet-ignore\test\DotnetIgnoreCliToolTests\DotnetIgnoreCliToolTests.csproj.
C:\Program Files\dotnet\sdk\2.1.403\Microsoft.Common.CurrentVersion.targets(2110,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "FluentAssertions". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors. [A:\dotnet-ignore\src\DotnetIgnoreCliTool\DotnetIgnoreCliTool.csproj]
  DotnetIgnoreCliTool -> A:\dotnet-ignore\src\DotnetIgnoreCliTool\bin\Debug\netcoreapp2.1\dotnet-ignore.dll
C:\Program Files\dotnet\sdk\2.1.403\Microsoft.Common.CurrentVersion.targets(2110,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "FluentAssertions". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors. [A:\dotnet-ignore\src\DotnetIgnoreCliTool\DotnetIgnoreCliTool.csproj]
  DotnetIgnoreCliTool -> A:\dotnet-ignore\src\DotnetIgnoreCliTool\bin\Debug\netcoreapp2.1\publish\
  Successfully created package 'A:\dotnet-ignore\src\DotnetIgnoreCliTool\bin\Debug\dotnet-ignore.1.0.3.nupkg'.
  DotnetIgnoreCliToolTests -> A:\dotnet-ignore\test\DotnetIgnoreCliToolTests\bin\Debug\netcoreapp2.1\DotnetIgnoreCliToolTests.dll

Build succeeded.

C:\Program Files\dotnet\sdk\2.1.403\Microsoft.Common.CurrentVersion.targets(2110,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "FluentAssertions". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors. [A:\dotnet-ignore\src\DotnetIgnoreCliTool\DotnetIgnoreCliTool.csproj]
C:\Program Files\dotnet\sdk\2.1.403\Microsoft.Common.CurrentVersion.targets(2110,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "FluentAssertions". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors. [A:\dotnet-ignore\src\DotnetIgnoreCliTool\DotnetIgnoreCliTool.csproj]
    2 Warning(s)
    0 Error(s)

Time Elapsed 00:00:02.03
```

This PR removes the unused reference to non-existent FluentAssertions so after applying it, the warning disappears:

```
Microsoft (R) Build Engine version 15.8.169+g1ccb72aefa for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 17.82 ms for A:\dotnet-ignore\test\DotnetIgnoreCliToolTests\DotnetIgnoreCliToolTests.csproj.
  Restore completed in 15.77 ms for A:\dotnet-ignore\src\DotnetIgnoreCliTool\DotnetIgnoreCliTool.csproj.
  Restore completed in 42.28 ms for A:\dotnet-ignore\test\DotnetIgnoreCliToolTests\DotnetIgnoreCliToolTests.csproj.
  DotnetIgnoreCliTool -> A:\dotnet-ignore\src\DotnetIgnoreCliTool\bin\Debug\netcoreapp2.1\dotnet-ignore.dll
  DotnetIgnoreCliTool -> A:\dotnet-ignore\src\DotnetIgnoreCliTool\bin\Debug\netcoreapp2.1\publish\
  Successfully created package 'A:\dotnet-ignore\src\DotnetIgnoreCliTool\bin\Debug\dotnet-ignore.1.0.3.nupkg'.
  DotnetIgnoreCliToolTests -> A:\dotnet-ignore\test\DotnetIgnoreCliToolTests\bin\Debug\netcoreapp2.1\DotnetIgnoreCliToolTests.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:01.29
```
